### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Mainalam7084/SteamWish/security/code-scanning/1](https://github.com/Mainalam7084/SteamWish/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal required permission is:

- `contents: read`

Best single fix without changing functionality:
- Insert the following between the `on:` trigger section and `jobs:`:
  ```yml
  permissions:
    contents: read
  ```
This preserves current CI behavior while constraining `GITHUB_TOKEN` to least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
