### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL scheme check

### DIFF
--- a/resources/js/interactions.js
+++ b/resources/js/interactions.js
@@ -189,7 +189,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const href = link.getAttribute('href');
 
-        if (!href || href.startsWith('#') || href.startsWith('javascript:') || link.getAttribute('target') === '_blank' || link.hasAttribute('download')) {
+        if (!href || href.startsWith('#') || href.startsWith('javascript:') || href.startsWith('data:') || href.startsWith('vbscript:') || link.getAttribute('target') === '_blank' || link.hasAttribute('download')) {
             return;
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Mainalam7084/SteamWish/security/code-scanning/2](https://github.com/Mainalam7084/SteamWish/security/code-scanning/2)

To fix this without changing intended functionality, extend the scheme guard at line 192 to also reject `data:` and `vbscript:` URLs, alongside `javascript:`.

Best concrete fix in `resources/js/interactions.js`:
- In the click handler block, update the `if` early-return condition that currently checks `href.startsWith('javascript:')`.
- Add `href.startsWith('data:')` and `href.startsWith('vbscript:')` to the same condition.

No new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation interception to properly exclude `data:` and `vbscript:` link types in addition to existing exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->